### PR TITLE
141 Added deployer user

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Nullstone
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Package files into tgz
+      - name: Package
+        run: tar -cvzf module.tgz *.tf
+
+      - name: Find version
+        id: version
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
+
+      # Publish to nullstone
+      - name: Publish
+        env:
+          NULLSTONE_ORG: nullstone
+          NULLSTONE_MODULE: aws-fargate
+          RELEASE_VERSION: ${{ steps.version.outputs.tag }}
+        run: |-
+          curl -XPOST -F "file=@module.tgz" -H "X-Nullstone-Key: ${{ secrets.NULLSTONE_API_KEY }}" \
+            https://api.nullstone.io/orgs/${NULLSTONE_ORG}/modules/${NULLSTONE_MODULE}/versions?version=${RELEASE_VERSION}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## 0.3.0 (Apr 13, 2021)
 
 * Added `deployer` user with explicit permission to deploy to this fargate cluster.
+* Added `cluster_arn` to outputs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.3.0 (Apr 13, 2021)
+
+* Added `deployer` user with explicit permission to deploy to this fargate cluster.

--- a/deployer.tf
+++ b/deployer.tf
@@ -1,0 +1,48 @@
+resource "aws_iam_user" "deployer" {
+  name = "deployer-${random_string.resource_suffix.result}"
+  tags = data.ns_workspace.this.tags
+}
+
+resource "aws_iam_access_key" "deployer" {
+  user = aws_iam_user.deployer.name
+}
+
+// The actions listed are necessary to perform actions to deploy ECS service
+resource "aws_iam_user_policy" "deployer" {
+  name   = "AllowECSDeploy"
+  user   = aws_iam_user.deployer.name
+  policy = data.aws_iam_policy_document.deployer.json
+}
+
+data "aws_iam_policy_document" "deployer" {
+  statement {
+    sid    = "AllowEditTaskDefinitions"
+    effect = "Allow"
+
+    actions = [
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition",
+      "ecs:DeregisterTaskDefinition",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowClusterUpdates"
+    effect = "Allow"
+
+    actions = [
+      "ecs:DescribeServices",
+      "ecs:UpdateService",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ecs:cluster"
+      values   = [aws_ecs_cluster.this.arn]
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,15 @@ output "cluster_execution_role_name" {
   value       = aws_iam_role.execution.name
   description = "string ||| "
 }
+
+output "deployer" {
+  value = {
+    name       = aws_iam_user.deployer.name
+    access_key = aws_iam_access_key.deployer.id
+    secret_key = aws_iam_access_key.deployer.secret
+  }
+
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to deploy ECS services."
+
+  sensitive = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,16 +1,21 @@
+output "cluster_arn" {
+  value       = aws_ecs_cluster.this.arn
+  description = "string ||| AWS Arn for the Fargate cluster."
+}
+
 output "cluster_name" {
   value       = aws_ecs_cluster.this.name
-  description = "string ||| "
+  description = "string ||| Name of the Fargate cluster."
 }
 
 output "service_discovery_id" {
   value       = aws_service_discovery_private_dns_namespace.service.id
-  description = "string ||| "
+  description = "string ||| AWS ID for the Private DNS namespace created for this cluster."
 }
 
 output "cluster_execution_role_name" {
   value       = aws_iam_role.execution.name
-  description = "string ||| "
+  description = "string ||| Name of AWS Role that is usually attached to each service for execution."
 }
 
 output "deployer" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,7 @@
+resource "random_string" "resource_suffix" {
+  length  = 5
+  lower   = true
+  upper   = false
+  number  = false
+  special = false
+}


### PR DESCRIPTION
This PR adds a deployer user with explicit permissions to update and deploy a service within this cluster.
Task Definitions are not specific to a cluster, so this user has permission to affect all task definitions in an account.
This user will be used by the nullstone CLI to perform `nullstone deploy ...` when deploying `app/container`.